### PR TITLE
fix issue #7 - broken document context initialization - GetVAFromSecOffset result check

### DIFF
--- a/DebugEngine/MagoNatDE/StackFrame.cpp
+++ b/DebugEngine/MagoNatDE/StackFrame.cpp
@@ -387,7 +387,7 @@ namespace Mago
             info.LineEnd.dwColumn--;
 
         info.Address = (Address64) session->GetVAFromSecOffset( line.Section, line.Offset );
-        if( info.Address )
+        if( !info.Address )
             return E_FAIL;
 
         MagoST::FileInfo    fileInfo = { 0 };


### PR DESCRIPTION
StackFrame.cpp 
info.Address = (Address64) session->GetVAFromSecOffset( line.Section, line.Offset );if( info.Address )

Current check:
if( info.Address )
return E_FAIL;

Fix:
if( !info.Address )
return E_FAIL;