### PR TITLE
mago-mi - ability to force external console

### DIFF
--- a/DebugEngine/MagoNatDE/Engine.cpp
+++ b/DebugEngine/MagoNatDE/Engine.cpp
@@ -501,8 +501,8 @@ namespace Mago
         info.StdOutput = (HANDLE) hStdOutput;
         info.StdError = (HANDLE) hStdError;
         info.Suspend = true;
-		if (pszOptions && std::wstring(pszOptions) == L"--external-console")
-			info.NewConsole = true;
+        if (pszOptions && std::wstring(pszOptions) == L"--external-console")
+            info.NewConsole = true;
 
         IDebuggerProxy* debugger = NULL;
 

--- a/DebugEngine/MagoNatDE/Engine.cpp
+++ b/DebugEngine/MagoNatDE/Engine.cpp
@@ -501,7 +501,7 @@ namespace Mago
         info.StdOutput = (HANDLE) hStdOutput;
         info.StdError = (HANDLE) hStdError;
         info.Suspend = true;
-		if ( (dwLaunchFlags & LAUNCH_NEW_CONSOLE) != 0 )
+        if ( (dwLaunchFlags & LAUNCH_NEW_CONSOLE) != 0 )
             info.NewConsole = true;
 
         IDebuggerProxy* debugger = NULL;

--- a/DebugEngine/MagoNatDE/Engine.cpp
+++ b/DebugEngine/MagoNatDE/Engine.cpp
@@ -501,7 +501,7 @@ namespace Mago
         info.StdOutput = (HANDLE) hStdOutput;
         info.StdError = (HANDLE) hStdError;
         info.Suspend = true;
-        if (pszOptions && std::wstring(pszOptions) == L"--external-console")
+		if ( (dwLaunchFlags & LAUNCH_NEW_CONSOLE) != 0 )
             info.NewConsole = true;
 
         IDebuggerProxy* debugger = NULL;

--- a/DebugEngine/MagoNatDE/Engine.cpp
+++ b/DebugEngine/MagoNatDE/Engine.cpp
@@ -501,6 +501,8 @@ namespace Mago
         info.StdOutput = (HANDLE) hStdOutput;
         info.StdError = (HANDLE) hStdError;
         info.Suspend = true;
+		if (pszOptions && std::wstring(pszOptions) == L"--external-console")
+			info.NewConsole = true;
 
         IDebuggerProxy* debugger = NULL;
 

--- a/DebugEngine/MagoNatDE/Engine.h
+++ b/DebugEngine/MagoNatDE/Engine.h
@@ -17,7 +17,7 @@
 
 enum LAUNCH_FLAGS_MAGO
 {
-	LAUNCH_NEW_CONSOLE = 0x8000
+    LAUNCH_NEW_CONSOLE = 0x8000
 };
 
 namespace Mago

--- a/DebugEngine/MagoNatDE/Engine.h
+++ b/DebugEngine/MagoNatDE/Engine.h
@@ -15,7 +15,7 @@
 #include "RemoteDebuggerProxy.h"
 #include "ExceptionTable.h"
 
-enum enum_LAUNCH_FLAGS_MAGO
+enum LAUNCH_FLAGS_MAGO
 {
 	LAUNCH_NEW_CONSOLE = 0x8000
 };

--- a/DebugEngine/MagoNatDE/Engine.h
+++ b/DebugEngine/MagoNatDE/Engine.h
@@ -15,6 +15,11 @@
 #include "RemoteDebuggerProxy.h"
 #include "ExceptionTable.h"
 
+enum enum_LAUNCH_FLAGS_MAGO
+{
+	LAUNCH_NEW_CONSOLE = 0x8000
+};
+
 namespace Mago
 {
     class Program;

--- a/MagoMI/mago-mi/source/MIEngine.cpp
+++ b/MagoMI/mago-mi/source/MIEngine.cpp
@@ -515,6 +515,7 @@ HRESULT MIEngine::Launch(
 			//WriteFile(hPipe, "test2\n", 5, &bytesWritten, NULL);
 		}
 	}
+	LAUNCH_FLAGS;
 	HRESULT hr = engine->LaunchSuspended(
 		NULL, //pszMachine,
 		debugPort, //IDebugPort2*          pPort,
@@ -522,8 +523,8 @@ HRESULT MIEngine::Launch(
 		pszArgs, //LPCOLESTR             pszArgs,
 		pszDir, //LPCOLESTR             pszDir,
 		NULL, //BSTR                  bstrEnv,
-		externalConsole ? L"--external-console" : NULL, //LPCOLESTR             pszOptions,
-		0, //LAUNCH_FLAGS          dwLaunchFlags,
+		NULL, //LPCOLESTR             pszOptions,
+		externalConsole ? LAUNCH_NEW_CONSOLE : 0, //LAUNCH_FLAGS          dwLaunchFlags,
 		(DWORD)hPipe, //DWORD                 hStdInput,
 		(DWORD)hPipe, //DWORD                 hStdOutput,
 		(DWORD)hPipe, //DWORD                 hStdError,

--- a/MagoMI/mago-mi/source/MIEngine.cpp
+++ b/MagoMI/mago-mi/source/MIEngine.cpp
@@ -482,19 +482,30 @@ HRESULT MIEngine::Launch(
 	HANDLE hPipe = NULL;
 	if (pszTerminalNamedPipe && pszTerminalNamedPipe[0]) {
 		CRLog::error("Terminal named pipe: %s", toUtf8z(pszTerminalNamedPipe));
+		SECURITY_ATTRIBUTES sa;
+		memset(&sa, 0, sizeof(sa));
+		sa.nLength = sizeof(sa);
+		sa.bInheritHandle = TRUE;
 		hPipe = CreateFile(
 			pszTerminalNamedPipe,   // pipe name 
 			GENERIC_READ |  // read and write access 
 			GENERIC_WRITE,
 			0,              // no sharing 
-			NULL,           // default security attributes
-			OPEN_EXISTING,  // opens existing pipe 
-			0,              // default attributes 
+			&sa,           // default security attributes
+			OPEN_EXISTING,  // opens existing pipe
+			FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH, // flags and attributes 
 			NULL);
 		if (hPipe == INVALID_HANDLE_VALUE) {
 			CRLog::error("Cannot open terminal named pipe %s result code is %d", toUtf8z(pszTerminalNamedPipe), GetLastError());
 			return E_FAIL;
 		}
+		//DWORD mode = PIPE_READMODE_BYTE | PIPE_WAIT;
+		//DWORD mode = PIPE_READMODE_MESSAGE | PIPE_WAIT;
+		//SetNamedPipeHandleState(hPipe, PIPE_READMODE_BYTE | PIPE_WAIT, NULL, NULL);
+		//SetNamedPipeHandleState(hPipe, &mode, NULL, NULL);
+		//DWORD bytesWritten = 0;
+		//WriteFile(hPipe, "test\n", 5, &bytesWritten, NULL);
+		//WriteFile(hPipe, "test2\n", 5, &bytesWritten, NULL);
 	}
 	HRESULT hr = engine->LaunchSuspended(
 		NULL, //pszMachine,

--- a/MagoMI/mago-mi/source/MIEngine.cpp
+++ b/MagoMI/mago-mi/source/MIEngine.cpp
@@ -493,7 +493,7 @@ HRESULT MIEngine::Launch(
 			0,              // no sharing 
 			&sa,           // default security attributes
 			OPEN_EXISTING,  // opens existing pipe
-			FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH, // flags and attributes 
+			FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH, // flags and attributes  
 			NULL);
 		if (hPipe == INVALID_HANDLE_VALUE) {
 			CRLog::error("Cannot open terminal named pipe %s result code is %d", toUtf8z(pszTerminalNamedPipe), GetLastError());

--- a/MagoMI/mago-mi/source/MIEngine.cpp
+++ b/MagoMI/mago-mi/source/MIEngine.cpp
@@ -480,32 +480,40 @@ HRESULT MIEngine::Launch(
 		const wchar_t * pszTerminalNamedPipe
 	) {
 	HANDLE hPipe = NULL;
+	bool externalConsole = false;
 	if (pszTerminalNamedPipe && pszTerminalNamedPipe[0]) {
-		CRLog::error("Terminal named pipe: %s", toUtf8z(pszTerminalNamedPipe));
-		SECURITY_ATTRIBUTES sa;
-		memset(&sa, 0, sizeof(sa));
-		sa.nLength = sizeof(sa);
-		sa.bInheritHandle = TRUE;
-		hPipe = CreateFile(
-			pszTerminalNamedPipe,   // pipe name 
-			GENERIC_READ |  // read and write access 
-			GENERIC_WRITE,
-			0,              // no sharing 
-			&sa,           // default security attributes
-			OPEN_EXISTING,  // opens existing pipe
-			FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH, // flags and attributes  
-			NULL);
-		if (hPipe == INVALID_HANDLE_VALUE) {
-			CRLog::error("Cannot open terminal named pipe %s result code is %d", toUtf8z(pszTerminalNamedPipe), GetLastError());
-			return E_FAIL;
+		std::wstring consoleName = pszTerminalNamedPipe;
+		if (consoleName == L"external-console") {
+			CRLog::info("Will create external console");
+			externalConsole = true;
 		}
-		//DWORD mode = PIPE_READMODE_BYTE | PIPE_WAIT;
-		//DWORD mode = PIPE_READMODE_MESSAGE | PIPE_WAIT;
-		//SetNamedPipeHandleState(hPipe, PIPE_READMODE_BYTE | PIPE_WAIT, NULL, NULL);
-		//SetNamedPipeHandleState(hPipe, &mode, NULL, NULL);
-		//DWORD bytesWritten = 0;
-		//WriteFile(hPipe, "test\n", 5, &bytesWritten, NULL);
-		//WriteFile(hPipe, "test2\n", 5, &bytesWritten, NULL);
+		else {
+			CRLog::error("Terminal named pipe: %s", toUtf8z(pszTerminalNamedPipe));
+			SECURITY_ATTRIBUTES sa;
+			memset(&sa, 0, sizeof(sa));
+			sa.nLength = sizeof(sa);
+			sa.bInheritHandle = TRUE;
+			hPipe = CreateFile(
+				pszTerminalNamedPipe,   // pipe name 
+				GENERIC_READ |  // read and write access 
+				GENERIC_WRITE,
+				0,              // no sharing 
+				&sa,           // default security attributes
+				OPEN_EXISTING,  // opens existing pipe
+				FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH, // flags and attributes  
+				NULL);
+			if (hPipe == INVALID_HANDLE_VALUE) {
+				CRLog::error("Cannot open terminal named pipe %s result code is %d", toUtf8z(pszTerminalNamedPipe), GetLastError());
+				return E_FAIL;
+			}
+			//DWORD mode = PIPE_READMODE_BYTE | PIPE_WAIT;
+			//DWORD mode = PIPE_READMODE_MESSAGE | PIPE_WAIT;
+			//SetNamedPipeHandleState(hPipe, PIPE_READMODE_BYTE | PIPE_WAIT, NULL, NULL);
+			//SetNamedPipeHandleState(hPipe, &mode, NULL, NULL);
+			//DWORD bytesWritten = 0;
+			//WriteFile(hPipe, "test\n", 5, &bytesWritten, NULL);
+			//WriteFile(hPipe, "test2\n", 5, &bytesWritten, NULL);
+		}
 	}
 	HRESULT hr = engine->LaunchSuspended(
 		NULL, //pszMachine,
@@ -514,7 +522,7 @@ HRESULT MIEngine::Launch(
 		pszArgs, //LPCOLESTR             pszArgs,
 		pszDir, //LPCOLESTR             pszDir,
 		NULL, //BSTR                  bstrEnv,
-		NULL, //LPCOLESTR             pszOptions,
+		externalConsole ? L"--external-console" : NULL, //LPCOLESTR             pszOptions,
 		0, //LAUNCH_FLAGS          dwLaunchFlags,
 		(DWORD)hPipe, //DWORD                 hStdInput,
 		(DWORD)hPipe, //DWORD                 hStdOutput,

--- a/MagoMI/mago-mi/source/cmdline.h
+++ b/MagoMI/mago-mi/source/cmdline.h
@@ -1,7 +1,7 @@
 #include <string>
 
 #define EMULATED_GDB_VERSION L"7.1.90"
-#define MAGO_MI_VERSION L"0.2.1"
+#define MAGO_MI_VERSION L"0.3.1"
 #define VERSION_STRING L"GNU gdb (mago-mi " MAGO_MI_VERSION L") " EMULATED_GDB_VERSION
 #define VERSION_EXPLANATION_STRING L"(Actually it's mago-mi debugger. Version shows GDB for Eclipse CDT compatibility)"
 

--- a/MagoMI/mago-mi/source/cmdline.h
+++ b/MagoMI/mago-mi/source/cmdline.h
@@ -1,7 +1,7 @@
 #include <string>
 
 #define EMULATED_GDB_VERSION L"7.1.90"
-#define MAGO_MI_VERSION L"0.3.1"
+#define MAGO_MI_VERSION L"0.3.2"
 #define VERSION_STRING L"GNU gdb (mago-mi " MAGO_MI_VERSION L") " EMULATED_GDB_VERSION
 #define VERSION_EXPLANATION_STRING L"(Actually it's mago-mi debugger. Version shows GDB for Eclipse CDT compatibility)"
 

--- a/MagoMI/mago-mi/source/cmdline.h
+++ b/MagoMI/mago-mi/source/cmdline.h
@@ -1,7 +1,7 @@
 #include <string>
 
 #define EMULATED_GDB_VERSION L"7.1.90"
-#define MAGO_MI_VERSION L"0.3.2"
+#define MAGO_MI_VERSION L"0.3.3"
 #define VERSION_STRING L"GNU gdb (mago-mi " MAGO_MI_VERSION L") " EMULATED_GDB_VERSION
 #define VERSION_EXPLANATION_STRING L"(Actually it's mago-mi debugger. Version shows GDB for Eclipse CDT compatibility)"
 

--- a/MagoMI/mago-mi/source/debugger.cpp
+++ b/MagoMI/mago-mi/source/debugger.cpp
@@ -378,7 +378,8 @@ void Debugger::handleDataEvaluateExpressionCommand(MICommand & cmd) {
 		return;
 	}
 	StackFrameInfo frameInfo;
-	bool hasContext = getThreadFrameContext(findThreadById(threadId), &frameInfo) == 1;
+	//bool hasContext = 
+	getThreadFrameContext(findThreadById(threadId), &frameInfo); // == 1;
 	LocalVariableList list;
 	if (frame && getLocalVariables(frame, list, true)) {
 		for (unsigned i = 0; i < list.size(); i++) {
@@ -435,7 +436,8 @@ void Debugger::handleVariableCommand(MICommand & cmd) {
 		return;
 	}
 	StackFrameInfo frameInfo;
-	bool hasContext = getThreadFrameContext(findThreadById(threadId), &frameInfo) == 1;
+	//bool hasContext = 
+	getThreadFrameContext(findThreadById(threadId), &frameInfo); // == 1;
 	if (addr == L"*") {
 		addr = frameInfo.address;
 	}
@@ -513,6 +515,7 @@ void Debugger::handleVariableCommand(MICommand & cmd) {
 
 // called to handle -stack-list-variables command
 void Debugger::handleStackListVariablesCommand(MICommand & cmd, bool localsOnly, bool argsOnly) {
+	UNREFERENCED_PARAMETER(argsOnly);
 	if (!_paused || _stopped) {
 		writeErrorMessage(cmd.requestId, L"Cannot get variables for running or terminated process");
 		return;
@@ -1154,7 +1157,6 @@ IDebugStackFrame2 * Debugger::getStackFrame(IDebugThread2 * pThread, unsigned fr
 		CRLog::error("cannot get thread frame enum");
 		return false;
 	}
-	unsigned outIndex = 0;
 	ULONG count = 0;
 	pFrames->GetCount(&count);
 	for (ULONG i = 0; i < count; i++) {
@@ -1179,6 +1181,7 @@ IDebugStackFrame2 * Debugger::getStackFrame(IDebugThread2 * pThread, unsigned fr
 
 // retrieves list of local variables from debug frame
 bool Debugger::getLocalVariables(IDebugStackFrame2 * frame, LocalVariableList &list, bool includeArgs) {
+	UNREFERENCED_PARAMETER(includeArgs);
 	if (!frame)
 		return NULL;
 	ULONG count = 0;
@@ -1678,7 +1681,7 @@ HRESULT Debugger::OnDebugBreakpointBound(IDebugEngine2 *pEngine,
 		CONTEXT_INFO info;
 		memset(&info, 0, sizeof(info));
 		if (SUCCEEDED(context->GetInfo(CIF_ALLFIELDS, &info))) {
-			int fnLine = info.posFunctionOffset.dwLine;
+			//int fnLine = info.posFunctionOffset.dwLine;
 			if (info.bstrFunction && info.bstrAddressOffset)
 				bp->functionName = std::wstring(info.bstrFunction) + std::wstring(info.bstrAddressOffset);
 			else if (info.bstrFunction)

--- a/MagoMI/mago-mi/source/debugger.h
+++ b/MagoMI/mago-mi/source/debugger.h
@@ -117,6 +117,9 @@ public:
 		PAUSED_BY_EXCEPTION,
 		PAUSED_BY_BREAK,
 	};
+	DWORD _exceptionCode;
+	std::wstring _exceptionName;
+	std::wstring _exceptionDescription;
 	void paused(IDebugThread2 * pThread, PauseReason reason, uint64_t requestId = UNSPECIFIED_REQUEST_ID, BreakpointInfo * bp = NULL);
 
 	// MIEventCallback interface


### PR DESCRIPTION
If --tty=external-console is set, run debuggee in new console.
MagoDE changes: LaunchSuspended pszOptions parameter == "--external-console" support is added - sets NewConsole flag for launch parameters.
