### PR TITLE
fix stack list variables format

### DIFF
--- a/MagoMI/mago-mi/source/debugger.cpp
+++ b/MagoMI/mago-mi/source/debugger.cpp
@@ -541,12 +541,13 @@ void Debugger::handleStackListVariablesCommand(MICommand & cmd, bool localsOnly,
 		return;
 	}
 	bool includeArgs = !localsOnly;
+	bool fullSyntax = !localsOnly;
 	LocalVariableList list;
 	if (frame && getLocalVariables(frame, list, includeArgs)) {
 		for (unsigned i = 0; i < list.size(); i++) {
 			if (i != 0)
 				buf.append(L",");
-			list[i]->dumpMiVariable(buf, level != PRINT_NO_VALUES ? true : false, level != PRINT_NO_VALUES ? true : false);
+			list[i]->dumpMiVariable(buf, level != PRINT_NO_VALUES ? true : false, level != PRINT_NO_VALUES ? true : false, fullSyntax);
 		}
 	}
 	

--- a/MagoMI/mago-mi/source/miutils.cpp
+++ b/MagoMI/mago-mi/source/miutils.cpp
@@ -397,8 +397,8 @@ std::wstring getBaseName(std::wstring fname) {
 	return fname;
 }
 
-void LocalVariableInfo::dumpMiVariable(WstringBuffer & buf, bool includeTypes, bool includeValues) {
-	if (!includeTypes && !includeValues) {
+void LocalVariableInfo::dumpMiVariable(WstringBuffer & buf, bool includeTypes, bool includeValues, bool fullSyntax) {
+	if (!includeTypes && !includeValues && !fullSyntax) {
 		//if (buf.last() != '[')
 		buf.appendStringLiteral(varName);
 	}

--- a/MagoMI/mago-mi/source/miutils.h
+++ b/MagoMI/mago-mi/source/miutils.h
@@ -432,7 +432,7 @@ public:
 	std::wstring varValue;
 	bool expandable;
 	bool readonly;
-	void dumpMiVariable(WstringBuffer & buf, bool includeTypes, bool includeValues);
+	void dumpMiVariable(WstringBuffer & buf, bool includeTypes, bool includeValues, bool fullSyntax);
 	LocalVariableInfo() : varKind(VAR_KIND_UNKNOWN), expandable(false), readonly(false) {}
 	virtual ~LocalVariableInfo() {}
 };


### PR DESCRIPTION
For command ```-stack-list-variables --thread 91672 --frame 0 --no-values```
mago-mi currently returns variables in format ["args","test"]

This format is not recognized by IntelliJ D plugin and also I didn't found any documentation that this format is valid.
Valid format is: [{name: "args"}, {name: "test"}]
Command -stack-list-variables is not used in DlangIDE and also the command dumpMiVariable
is only used in -stack-list-variables case. Therefore DLangIDE is not affected.

The change is to remove the unknown short version ["args","test"] and force the valid long version.
